### PR TITLE
Rename Turbo pipeline key to tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
-  "pipeline": {
+  "tasks": {
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".next/**"]


### PR DESCRIPTION
## Summary
- rename the root Turbo config key from `pipeline` to `tasks` to match the expected schema

## Testing
- pnpm turbo run build *(fails: Command "turbo" not found)*
- pnpm build *(fails: turbo: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e04ab10b048325a9162ef78030d9e5