### PR TITLE
Fix JSON openings in tsconfig files

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,5 +1,4 @@
 {
-{
   "extends": "../../packages/tsconfig/nest.json",
   "compilerOptions": {
     "module": "commonjs",

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,5 +1,4 @@
 {
-{
   "extends": "../../packages/tsconfig/next.json",
   "compilerOptions": {
     "baseUrl": ".",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,4 @@
 {
-{
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "./packages/tsconfig/base.json",
   "compilerOptions": {


### PR DESCRIPTION
## Summary
- remove the duplicated opening brace from the root tsconfig
- fix the opening brace in the web app tsconfig
- fix the opening brace in the api app tsconfig

## Testing
- pnpm exec jq . tsconfig.json
- pnpm exec jq . apps/web/tsconfig.json
- pnpm exec jq . apps/api/tsconfig.json
- pnpm --filter web build *(fails: Next.js build aborts due to missing runtime configuration and dynamic routes)*
- pnpm --filter api build *(fails: Nest build aborts because of unresolved Prisma types and Stripe mocks)*

------
https://chatgpt.com/codex/tasks/task_e_68e054a3cef08325905cdeb9d0200e33